### PR TITLE
[Translation][Bridge][Lokalise] Fix empty keys array in PUT, DELETE requests causing Lokalise API error

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -421,9 +421,8 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             }
         }
 
-        return static function ($ch, string $location, bool $noContent, bool &$locationHasHost) use (&$redirectHeaders, $options) {
+        return static function ($ch, string $location, bool $noContent) use (&$redirectHeaders, $options) {
             try {
-                $locationHasHost = false;
                 $location = self::parseUrl($location);
                 $url = self::parseUrl(curl_getinfo($ch, \CURLINFO_EFFECTIVE_URL));
                 $url = self::resolveUrl($location, $url);
@@ -439,9 +438,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
                 $redirectHeaders['with_auth'] = array_filter($redirectHeaders['with_auth'], $filterContentHeaders);
             }
 
-            $locationHasHost = isset($location['authority']);
-
-            if ($redirectHeaders && $locationHasHost) {
+            if ($redirectHeaders && isset($location['authority'])) {
                 $requestHeaders = parse_url($location['authority'], \PHP_URL_HOST) === $redirectHeaders['host'] ? $redirectHeaders['with_auth'] : $redirectHeaders['no_auth'];
                 curl_setopt($ch, \CURLOPT_HTTPHEADER, $requestHeaders);
             } elseif ($noContent && $redirectHeaders) {

--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -156,6 +156,7 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
 
                 $progressInfo = $info;
                 $progressInfo['url'] = implode('', $info['url']);
+                $progressInfo['resolve'] = $resolve;
                 unset($progressInfo['size_body']);
 
                 if ($progress && -1 === $progress[0]) {
@@ -165,7 +166,7 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
                     $lastProgress = $progress ?: $lastProgress;
                 }
 
-                $onProgress($lastProgress[0], $lastProgress[1], $progressInfo, $resolve);
+                $onProgress($lastProgress[0], $lastProgress[1], $progressInfo);
             };
         } elseif (0 < $options['max_duration']) {
             $maxDuration = $options['max_duration'];
@@ -348,6 +349,7 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
 
             $multi->dnsCache[$host] = $ip = $ip[0];
             $info['debug'] .= "* Added {$host}:0:{$ip} to DNS cache\n";
+            $host = $ip;
         } else {
             $info['debug'] .= "* Hostname was found in DNS cache\n";
             $host = str_contains($ip, ':') ? "[$ip]" : $ip;

--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -80,24 +80,17 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
         $lastUrl = '';
         $lastPrimaryIp = '';
 
-        $options['on_progress'] = function (int $dlNow, int $dlSize, array $info, ?\Closure $resolve = null) use ($onProgress, $subnets, &$lastUrl, &$lastPrimaryIp): void {
+        $options['on_progress'] = function (int $dlNow, int $dlSize, array $info) use ($onProgress, $subnets, &$lastUrl, &$lastPrimaryIp): void {
             if ($info['url'] !== $lastUrl) {
-                $host = trim(parse_url($info['url'], PHP_URL_HOST) ?: '', '[]');
+                $host = parse_url($info['url'], PHP_URL_HOST) ?: '';
+                $resolve = $info['resolve'] ?? static function () { return null; };
 
-                if (null === $resolve) {
-                    $resolve = static function () { return null; };
-                }
-
-                if (($ip = $host)
-                    && !filter_var($ip, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)
-                    && !filter_var($ip, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4)
-                    && !$ip = $resolve($host)
+                if (($ip = trim($host, '[]'))
+                    && !filter_var($ip, \FILTER_VALIDATE_IP)
+                    && !($ip = $resolve($host))
+                    && $ip = @(gethostbynamel($host)[0] ?? dns_get_record($host, \DNS_AAAA)[0]['ipv6'] ?? null)
                 ) {
-                    if ($ip = @(dns_get_record($host, \DNS_A)[0]['ip'] ?? null)) {
-                        $resolve($host, $ip);
-                    } elseif ($ip = @(dns_get_record($host, \DNS_AAAA)[0]['ipv6'] ?? null)) {
-                        $resolve($host, '['.$ip.']');
-                    }
+                    $resolve($host, $ip);
                 }
 
                 if ($ip && IpUtils::checkIp($ip, $subnets ?? self::PRIVATE_SUBNETS)) {

--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -99,7 +99,8 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
         $onProgress = $options['on_progress'] ?? static function () {};
         $onProgress = $this->onProgress = static function () use (&$info, $onProgress, $resolve) {
             $info['total_time'] = microtime(true) - $info['start_time'];
-            $onProgress((int) $info['size_download'], ((int) (1 + $info['download_content_length']) ?: 1) - 1, (array) $info, $resolve);
+            $info['resolve'] = $resolve;
+            $onProgress((int) $info['size_download'], ((int) (1 + $info['download_content_length']) ?: 1) - 1, (array) $info);
         };
 
         $pauseDeferred = new Deferred();

--- a/src/Symfony/Component/HttpClient/Response/AsyncContext.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncContext.php
@@ -156,8 +156,8 @@ final class AsyncContext
         $this->info['previous_info'][] = $info = $this->response->getInfo();
         if (null !== $onProgress = $options['on_progress'] ?? null) {
             $thisInfo = &$this->info;
-            $options['on_progress'] = static function (int $dlNow, int $dlSize, array $info, ?\Closure $resolve = null) use (&$thisInfo, $onProgress) {
-                $onProgress($dlNow, $dlSize, $thisInfo + $info, $resolve);
+            $options['on_progress'] = static function (int $dlNow, int $dlSize, array $info) use (&$thisInfo, $onProgress) {
+                $onProgress($dlNow, $dlSize, $thisInfo + $info);
             };
         }
         if (0 < ($info['max_duration'] ?? 0) && 0 < ($info['total_time'] ?? 0)) {

--- a/src/Symfony/Component/HttpClient/TraceableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/TraceableHttpClient.php
@@ -58,11 +58,11 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface, 
             $content = false;
         }
 
-        $options['on_progress'] = function (int $dlNow, int $dlSize, array $info, ?\Closure $resolve = null) use (&$traceInfo, $onProgress) {
+        $options['on_progress'] = function (int $dlNow, int $dlSize, array $info) use (&$traceInfo, $onProgress) {
             $traceInfo = $info;
 
             if (null !== $onProgress) {
-                $onProgress($dlNow, $dlSize, $info, $resolve);
+                $onProgress($dlNow, $dlSize, $info);
             }
         };
 

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -621,6 +621,10 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                 return false;
             }
 
+            if (\PHP_VERSION_ID >= 80400 && $writeAccessRequired && ($reflectionProperty->isProtectedSet() || $reflectionProperty->isPrivateSet())) {
+                return false;
+            }
+
             return (bool) ($reflectionProperty->getModifiers() & $this->propertyReflectionFlags);
         } catch (\ReflectionException $e) {
             // Return false if the property doesn't exist

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyReadInfo;
 use Symfony\Component\PropertyInfo\PropertyWriteInfo;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\AsymmetricVisibility;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NotInstantiable;
@@ -684,5 +685,18 @@ class ReflectionExtractorTest extends TestCase
             ['dateTime', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime')]],
             ['ddd', null],
         ];
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testAsymmetricVisibility()
+    {
+        $this->assertTrue($this->extractor->isReadable(AsymmetricVisibility::class, 'publicPrivate'));
+        $this->assertTrue($this->extractor->isReadable(AsymmetricVisibility::class, 'publicProtected'));
+        $this->assertFalse($this->extractor->isReadable(AsymmetricVisibility::class, 'protectedPrivate'));
+        $this->assertFalse($this->extractor->isWritable(AsymmetricVisibility::class, 'publicPrivate'));
+        $this->assertFalse($this->extractor->isWritable(AsymmetricVisibility::class, 'publicProtected'));
+        $this->assertFalse($this->extractor->isWritable(AsymmetricVisibility::class, 'protectedPrivate'));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/AsymmetricVisibility.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/AsymmetricVisibility.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class AsymmetricVisibility
+{
+    public private(set) mixed $publicPrivate;
+    public protected(set) mixed $publicProtected;
+    protected private(set) mixed $protectedPrivate;
+}

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -129,6 +129,10 @@ final class LokaliseProvider implements ProviderInterface
             $keysIds += $this->getKeysIds($keysToDelete, $domain);
         }
 
+        if (0 === \count($keysIds)) {
+            return;
+        }
+
         $response = $this->client->request('DELETE', 'keys', [
             'json' => ['keys' => array_values($keysIds)],
         ]);

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -265,6 +265,10 @@ final class LokaliseProvider implements ProviderInterface
             }
         }
 
+        if (0 === \count($keysToUpdate)) {
+            return;
+        }
+
         $response = $this->client->request('PUT', 'keys', [
             'json' => ['keys' => $keysToUpdate],
         ]);

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -249,6 +249,56 @@ class LokaliseProviderTest extends ProviderTestCase
         $this->assertTrue($updateProcessed, 'Translations update was not called.');
     }
 
+    public function testUpdateProcessWhenLocalTranslationsMatchLokaliseTranslations()
+    {
+        $getLanguagesResponse = function (string $method, string $url): ResponseInterface {
+            $this->assertSame('GET', $method);
+            $this->assertSame('https://api.lokalise.com/api2/projects/PROJECT_ID/languages', $url);
+
+            return new MockResponse(json_encode([
+                'languages' => [
+                    ['lang_iso' => 'en'],
+                    ['lang_iso' => 'fr'],
+                ],
+            ]));
+        };
+
+        $failOnPutRequest = function (string $method, string $url, array $options = []): void {
+            $this->assertSame('PUT', $method);
+            $this->assertSame('https://api.lokalise.com/api2/projects/PROJECT_ID/keys', $url);
+            $this->assertSame(json_encode(['keys' => []]), $options['body']);
+
+            $this->fail('PUT request is invalid: an empty `keys` array was provided, resulting in a Lokalise API error');
+        };
+
+        $mockHttpClient = (new MockHttpClient([
+            $getLanguagesResponse,
+            $failOnPutRequest,
+        ]))->withOptions([
+            'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
+            'headers' => ['X-Api-Token' => 'API_KEY'],
+        ]);
+
+        $provider = self::createProvider(
+            $mockHttpClient,
+            $this->getLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.lokalise.com'
+        );
+
+        // TranslatorBag with catalogues that do not store any message to mimic the behaviour of
+        // Symfony\Component\Translation\Command\TranslationPushCommand when local translations and Lokalise
+        // translations match without any changes in both translation sets
+        $translatorBag = new TranslatorBag();
+        $translatorBag->addCatalogue(new MessageCatalogue('en', []));
+        $translatorBag->addCatalogue(new MessageCatalogue('fr', []));
+
+        $provider->write($translatorBag);
+
+        $this->assertSame(1, $mockHttpClient->getRequestsCount());
+    }
+
     public function testWriteGetLanguageServerError()
     {
         $getLanguagesResponse = function (string $method, string $url, array $options = []): ResponseInterface {

--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -48,11 +48,9 @@ interface HttpClientInterface
         'buffer' => true,       // bool|resource|\Closure - whether the content of the response should be buffered or not,
                                 //   or a stream resource where the response body should be written,
                                 //   or a closure telling if/where the response should be buffered based on its headers
-        'on_progress' => null,  // callable(int $dlNow, int $dlSize, array $info, ?Closure $resolve = null) - throwing any
-                                //   exceptions MUST abort the request; it MUST be called on connection, on headers and on
-                                //   completion; it SHOULD be called on upload/download of data and at least 1/s;
-                                //   if passed, $resolve($host) / $resolve($host, $ip) can be called to read / populate
-                                //   the DNS cache respectively
+        'on_progress' => null,  // callable(int $dlNow, int $dlSize, array $info) - throwing any exceptions MUST abort the
+                                //   request; it MUST be called on connection, on headers and on completion; it SHOULD be
+                                //   called on upload/download of data and at least 1/s
         'resolve' => [],        // string[] - a map of host to IP address that SHOULD replace DNS resolution
         'proxy' => null,        // string - by default, the proxy-related env vars handled by curl SHOULD be honored
         'no_proxy' => null,     // string - a comma separated list of hosts that do not require a proxy to be reached


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | /
| License       | MIT

This PR fixes two cases where an empty `keys` array is passed to a `PUT`/`DELETE` request, resulting in a Lokalise API error.

The empty arrays are the result of a `Symfony\Component\Translation\TranslatorBag` containing one or more `Symfony\Component\Translation\MessageCatalogue` _without any_ messages getting passed into the `Symfony\Component\Translation\Bridge\Lokalise\LokaliseProvider` (which is expected behaviour, see [here](https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Translation/Command/TranslationPushCommand.php#L153) and below).

This is the case if either
* `bin/console translation:push lokalise`
* `bin/console translation:push lokalise --delete-missing`

is called when both the local translations as well as the translations on Lokalise match 1:1 for a given translation domain.

This will fix the following erros that might be observed while running the mentioned commands:

<details>
<summary>Before/after for <code>translation:push lokalise</code></summary>

**Before:**
```console
$ bin/console translation:push lokalise --domains=validators

ERROR     [app] Unable to get keys ids from Lokalise: "{"error":{"message":"`filter_filenames` parameter has invalid values","code":400}}".

                                                                                                                     
 [OK] All local translations has been sent to "lokalise" (for "de, en, fr, it" locale(s), and "validators"           
      domain(s)).
```

**After:**
```console
$ bin/console translation:push lokalise --domains=validators

                                                                                                                     
 [OK] All local translations has been sent to "lokalise" (for "de, en, fr, it" locale(s), and "validators"           
      domain(s)).
```

</details>

<details>
<summary>Before/after for <code>translation:push lokalise --delete-missing</code></summary>

**Before:**
```console
$ bin/console translation:push lokalise --domains=validators --delete-missing

In LokaliseProvider.php line 135:
                                                                                                            
  Unable to delete keys from Lokalise: "{"error":{"message":"`keys` parameter is not valid","code":400}}".  
                                                                                                            

translation:push [--force] [--delete-missing] [--domains [DOMAINS]] [--locales [LOCALES]] [--] [<provider>]
```

**After:**
```console
$ bin/console translation:push lokalise --domains=validators --delete-missing

                                                                                                                     
 [OK] Missing translations on "lokalise" has been deleted (for "de, en, fr, it" locale(s), and "validators"           
      domain(s)).

                                                                                                                     
 [OK] All local translations has been sent to "lokalise" (for "de, en, fr, it" locale(s), and "validators"           
      domain(s)).
```

</details>